### PR TITLE
feat: add the color shortcode

### DIFF
--- a/assets/hb/modules/shortcodes/scss/_color.scss
+++ b/assets/hb/modules/shortcodes/scss/_color.scss
@@ -1,0 +1,12 @@
+.hb-color {
+  &::after {
+    content: '';
+    background: var(--color);
+    border: 1px solid var(--#{$prefix}dark);
+    display: inline-block;
+    height: 0.8rem;
+    margin-left: .125rem;
+    width: 0.8rem;
+    vertical-align: -0.125rem;
+  }
+}

--- a/assets/hb/modules/shortcodes/scss/index.scss
+++ b/assets/hb/modules/shortcodes/scss/index.scss
@@ -1,1 +1,2 @@
+@import 'color';
 @import 'spoiler-tag';

--- a/layouts/shortcodes/color.html
+++ b/layouts/shortcodes/color.html
@@ -1,0 +1,4 @@
+{{- $color := .Get 0 }}
+<code
+  class="hb-color user-select-all"
+  style="--color: {{ $color }};">{{ $color }}</code>


### PR DESCRIPTION
```markdown
e.g. {{< color blue >}}, {{< color red >}}, {{< color "#FF438A" >}}.
```

![image](https://github.com/hbstack/shortcodes/assets/17720932/eb860197-eff1-40c9-878f-e3df94a1cda9)
